### PR TITLE
fix: allow ArcGIS tile images in CSP and ignore .vscode/.agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ specimens.tsv
 *.sql
 specimens.json
 *.local.md
+.vscode
+.agents

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ const CSP = [
   "script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com",
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "font-src 'self' https://fonts.gstatic.com",
-  "img-src 'self' data: https://*.tile.openstreetmap.org https://inaturalist-open-data.s3.amazonaws.com https://static.inaturalist.org",
+  "img-src 'self' data: https://server.arcgisonline.com https://*.tile.openstreetmap.org https://inaturalist-open-data.s3.amazonaws.com https://static.inaturalist.org",
   "connect-src 'self' https://api.inaturalist.org",
   "object-src 'none'",
   "base-uri 'self'",


### PR DESCRIPTION
Adds server.arcgisonline.com to the img-src CSP directive so satellite tiles load without being blocked. Also ignores .vscode and .agents dirs.