### PR TITLE
feat: species grid cards, observations filtering, and weather data request dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ specimens.json
 .vscode
 .agents
 .playwright-mcp
+tpwd-sgcn-list.csv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ Prettier enforced: no semicolons, single quotes, trailing commas.
 
 Env vars live in `.env.local` (the dev server loads it automatically). Both local and production require `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` — `getTurso()` throws if either is missing. For local data, set `TURSO_DATABASE_URL=file:imrs-species.db` with any non-empty `TURSO_AUTH_TOKEN` (required but ignored for `file:` URLs).
 
+The weather-data request form (`WeatherDataRequestDialog`) posts to Formspree using `VITE_FORMSPREE_FORM_ID` (the `VITE_` prefix exposes it to the client). Set it to your Formspree form ID; without it the form shows an error instead of submitting.
+
 ## Accessibility
 
 **Target**: WCAG 2.1 AA compliance.

--- a/README.md
+++ b/README.md
@@ -177,11 +177,12 @@ that fetches conservation status from two free sources:
   NatureServe only and skips IUCN.
 
 A third source, **Texas SGCN** (Species of Greatest Conservation Need), comes
-from the TPWD State Wildlife Action Plan. TPWD has no public API, so its list
-ships as a static CSV at `src/data/tpwd-sgcn-list.csv` and is seeded by a
-separate script that flags the `texas_sgcn` column for any specimen whose
-binomial matches the list. SGCN is binary (listed / not listed), so it renders
-as a flag badge rather than a 1–5 rank.
+from the TPWD State Wildlife Action Plan. TPWD has no public API, so you must
+supply its list as a local CSV at `src/data/tpwd-sgcn-list.csv` (git-ignored, not
+committed — a fresh clone won't have it). It's then seeded by a separate script
+that flags the `texas_sgcn` column for any specimen whose binomial matches the
+list. SGCN is binary (listed / not listed), so it renders as a flag badge rather
+than a 1–5 rank.
 
 These calls happen only at seed time — the app makes no external conservation
 requests at runtime. The scripts add their columns idempotently (so they're safe

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The **IMRS Biodiversity Explorer** turns that handbook into a living, interactiv
 ## Features
 
 - **Species Catalog** — search and filter every species ever recorded at the station, in a visual grid or a detailed table.
-- **Conservation Status** — at-a-glance badges show how each species is doing, drawn from NatureServe and the IUCN Red List.
+- **Conservation Status** — at-a-glance badges show how each species is doing, drawn from NatureServe, the IUCN Red List, and the Texas SGCN (Species of Greatest Conservation Need) list.
 - **Recent Observations** — Real-time integration with the **iNaturalist API** to display the latest confirmed sightings at IMRS
 - **Climate & Weather** — five years (2020–2024) of the station's weather, charted and filterable by year and season.
 - **Gazetteer** — an interactive map of the named places across the station.
@@ -129,7 +129,8 @@ CREATE TABLE specimens (
   iucn_category TEXT,
   natureserve_grank TEXT,
   natureserve_srank_tx TEXT,
-  natureserve_id TEXT
+  natureserve_id TEXT,
+  texas_sgcn TEXT
 );
 
 # Import Data (ensure specimens.tsv is in root)
@@ -166,8 +167,8 @@ turso db import imrs-species.db
 
 ### 3. Conservation Status
 
-The four `iucn_category` / `natureserve_*` columns are populated by a seed
-script that fetches conservation status from two free sources:
+The `iucn_category` / `natureserve_*` columns are populated by a seed script
+that fetches conservation status from two free sources:
 
 - **NatureServe Explorer** — no API key. Provides the global G-rank and the
   Texas subnational S-rank.
@@ -175,14 +176,24 @@ script that fetches conservation status from two free sources:
   `IUCN_API_TOKEN` in `.env.local`. If it's omitted, the script seeds
   NatureServe only and skips IUCN.
 
+A third source, **Texas SGCN** (Species of Greatest Conservation Need), comes
+from the TPWD State Wildlife Action Plan. TPWD has no public API, so its list
+ships as a static CSV at `src/data/tpwd-sgcn-list.csv` and is seeded by a
+separate script that flags the `texas_sgcn` column for any specimen whose
+binomial matches the list. SGCN is binary (listed / not listed), so it renders
+as a flag badge rather than a 1–5 rank.
+
 These calls happen only at seed time — the app makes no external conservation
-requests at runtime. The script adds the columns idempotently (so it's safe on
-an existing DB) and is resumable (it skips species that already have data; pass
-`--force` to reprocess all).
+requests at runtime. The scripts add their columns idempotently (so they're safe
+on an existing DB); `seed-conservation.ts` is resumable (it skips species that
+already have data; pass `--force` to reprocess all).
 
 ```bash
 # Seed the local DB (NatureServe + IUCN)
 IUCN_API_TOKEN=your_token npx tsx scripts/seed-conservation.ts
+
+# Seed the Texas SGCN flag (no token needed)
+npx tsx scripts/seed-sgcn.ts
 ```
 
 To propagate the seeded data to the **existing** production Turso DB, update it
@@ -197,7 +208,8 @@ DB and apply it with `turso db shell`:
   echo "ALTER TABLE specimens ADD COLUMN natureserve_grank TEXT;"
   echo "ALTER TABLE specimens ADD COLUMN natureserve_srank_tx TEXT;"
   echo "ALTER TABLE specimens ADD COLUMN natureserve_id TEXT;"
-  sqlite3 imrs-species.db "SELECT 'UPDATE specimens SET iucn_category='||quote(iucn_category)||', natureserve_grank='||quote(natureserve_grank)||', natureserve_srank_tx='||quote(natureserve_srank_tx)||', natureserve_id='||quote(natureserve_id)||' WHERE id='||id||';' FROM specimens WHERE iucn_category IS NOT NULL OR natureserve_grank IS NOT NULL OR natureserve_srank_tx IS NOT NULL OR natureserve_id IS NOT NULL;"
+  echo "ALTER TABLE specimens ADD COLUMN texas_sgcn TEXT;"
+  sqlite3 imrs-species.db "SELECT 'UPDATE specimens SET iucn_category='||quote(iucn_category)||', natureserve_grank='||quote(natureserve_grank)||', natureserve_srank_tx='||quote(natureserve_srank_tx)||', natureserve_id='||quote(natureserve_id)||', texas_sgcn='||quote(texas_sgcn)||' WHERE id='||id||';' FROM specimens WHERE iucn_category IS NOT NULL OR natureserve_grank IS NOT NULL OR natureserve_srank_tx IS NOT NULL OR natureserve_id IS NOT NULL OR texas_sgcn IS NOT NULL;"
 } > conservation-updates.sql
 
 # Apply to the production DB (the ALTERs are one-time; ignore "duplicate column" if re-running)
@@ -208,8 +220,9 @@ rm conservation-updates.sql
 > The columns must exist in production for the badges to render. If one is
 > missing the app degrades gracefully (no badge) — it does not error.
 
-Conservation data courtesy of [NatureServe Explorer](https://explorer.natureserve.org/)
-and the [IUCN Red List](https://www.iucnredlist.org/).
+Conservation data courtesy of [NatureServe Explorer](https://explorer.natureserve.org/),
+the [IUCN Red List](https://www.iucnredlist.org/), and the
+[Texas Parks & Wildlife SGCN list](https://tpwd.texas.gov/wildlife/wildlife-diversity/swap/sgcn/).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@libsql/client": "^0.17.3",
+    "@radix-ui/react-dialog": "^1.1.17",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/vite": "^4.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@libsql/client':
         specifier: ^0.17.3
         version: 0.17.3
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.17
+        version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -717,6 +720,9 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -752,6 +758,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
@@ -761,8 +776,30 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dialog@1.1.15':
     resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.17':
+    resolution: {integrity: sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -796,6 +833,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.13':
+    resolution: {integrity: sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -803,6 +853,28 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.4':
+    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.10':
+    resolution: {integrity: sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-focus-scope@1.1.7':
@@ -827,8 +899,30 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-popper@1.2.8':
     resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.12':
+    resolution: {integrity: sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -866,8 +960,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.6':
+    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.6':
+    resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -910,8 +1030,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -928,8 +1066,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -946,8 +1102,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-escape-keydown@1.1.2':
+    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4624,6 +4798,8 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/primitive@1.1.4': {}
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -4651,7 +4827,19 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       react: 19.2.6
     optionalDependencies:
@@ -4679,6 +4867,28 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-dialog@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -4698,11 +4908,41 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-dismissable-layer@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -4722,6 +4962,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -4734,6 +4981,16 @@ snapshots:
       '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/rect': 1.1.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
@@ -4760,9 +5017,27 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
@@ -4812,7 +5087,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       react: 19.2.6
     optionalDependencies:
@@ -4826,9 +5114,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
@@ -4840,7 +5143,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       react: 19.2.6
     optionalDependencies:

--- a/scripts/conservation-sources.test.ts
+++ b/scripts/conservation-sources.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   extractNatureServe,
   findNatureServeMatch,
+  isSgcnListed,
+  parseSgcnBinomials,
   pickLatestIucnCategory,
   pickTexasSRank,
 } from './conservation-sources'
@@ -98,5 +100,37 @@ describe('pickLatestIucnCategory', () => {
   it('returns null for empty or missing assessments', () => {
     expect(pickLatestIucnCategory([])).toBeNull()
     expect(pickLatestIucnCategory(undefined)).toBeNull()
+  })
+})
+
+describe('parseSgcnBinomials', () => {
+  // A trailing quoted habitat field with embedded commas must not corrupt the
+  // scientific_name read (column 2 always precedes it).
+  const CSV = [
+    'taxonomic_group,scientific_name,common_name,federal_status,general_habitat',
+    'Amphibians,Anaxyrus houstonensis,Houston toad,E,"Forests, dunes, and pools"',
+    'Mammals,Corynorhinus townsendii,Townsend’s big-eared bat,Not Listed,"Caves, mines"',
+    '',
+  ].join('\n')
+
+  it('reads lowercased binomials from column 2, skipping the header', () => {
+    const names = parseSgcnBinomials(CSV)
+    expect(names.has('anaxyrus houstonensis')).toBe(true)
+    expect(names.has('corynorhinus townsendii')).toBe(true)
+    expect(names.has('scientific_name')).toBe(false)
+    expect(names.size).toBe(2)
+  })
+})
+
+describe('isSgcnListed', () => {
+  const listed = new Set(['corynorhinus townsendii'])
+
+  it('matches a binomial exactly, case- and whitespace-insensitive', () => {
+    expect(isSgcnListed('Corynorhinus', 'townsendii', listed)).toBe(true)
+    expect(isSgcnListed(' corynorhinus ', ' TOWNSENDII ', listed)).toBe(true)
+  })
+
+  it('does not match an absent binomial', () => {
+    expect(isSgcnListed('Canis', 'lupus', listed)).toBe(false)
   })
 })

--- a/scripts/conservation-sources.ts
+++ b/scripts/conservation-sources.ts
@@ -86,3 +86,32 @@ export function pickLatestIucnCategory(
   const latest = assessments.find((a) => a.latest) ?? assessments[0]
   return latest.red_list_category_code ?? null
 }
+
+// --- Texas SGCN (static TPWD State Wildlife Action Plan list) ---
+
+/**
+ * Parse the lowercased binomial scientific names from the TPWD SGCN CSV.
+ *
+ * The CSV header is `taxonomic_group,scientific_name,...` — only column 2
+ * (`scientific_name`) is needed, and neither it nor column 1 contains embedded
+ * commas (the only messy quoted field, `general_habitat`, is last), so a plain
+ * comma split taking index 1 is safe. The header row is skipped.
+ */
+export function parseSgcnBinomials(csvText: string): Set<string> {
+  const names = new Set<string>()
+  const lines = csvText.split(/\r?\n/)
+  for (const line of lines.slice(1)) {
+    const name = line.split(',')[1]?.trim().toLowerCase()
+    if (name) names.add(name)
+  }
+  return names
+}
+
+/** Whether a genus + species is on the SGCN list (exact binomial match). */
+export function isSgcnListed(
+  genus: string,
+  species: string,
+  listed: Set<string>,
+): boolean {
+  return listed.has(`${genus.trim()} ${species.trim()}`.toLowerCase())
+}

--- a/scripts/seed-sgcn.ts
+++ b/scripts/seed-sgcn.ts
@@ -1,0 +1,84 @@
+/**
+ * Seed script: flag specimens that are Texas Species of Greatest Conservation
+ * Need (SGCN).
+ *
+ * Unlike NatureServe and IUCN (seeded from live APIs by seed-conservation.ts),
+ * the Texas Parks & Wildlife Department (TPWD) State Wildlife Action Plan SGCN
+ * list has no public API, so it ships as a static CSV checked into the repo at
+ * src/data/tpwd-sgcn-list.csv. This script adds a nullable `texas_sgcn` column
+ * to the existing `specimens` table and sets it to 'SGCN' for every specimen
+ * whose binomial (genus + species) exactly matches a name on the list.
+ *
+ * SGCN is binary (listed / not listed), so there is no rank to store — the
+ * column's presence is the signal. The script AUGMENTS the existing DB (never
+ * drops it) and is safe to re-run: it recomputes the flag for every specimen.
+ *
+ * Usage:
+ *   npx tsx scripts/seed-sgcn.ts
+ *
+ * Then push to Turso (production):
+ *   sqlite3 imrs-species.db "PRAGMA wal_checkpoint(TRUNCATE);"
+ *   turso db import imrs-species.db
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { isSgcnListed, parseSgcnBinomials } from './conservation-sources'
+
+const DB_PATH = path.join(process.cwd(), 'imrs-species.db')
+const CSV_PATH = path.join(process.cwd(), 'src/data/tpwd-sgcn-list.csv')
+
+interface SpecimenRow {
+  id: number
+  genus: string
+  species: string
+}
+
+function ensureColumn(db: Database.Database) {
+  try {
+    db.exec('ALTER TABLE specimens ADD COLUMN texas_sgcn TEXT')
+  } catch (err) {
+    // Re-runnable: ignore "duplicate column name" if it already exists.
+    if (!String((err as Error).message).includes('duplicate column')) throw err
+  }
+}
+
+function main() {
+  const listed = parseSgcnBinomials(fs.readFileSync(CSV_PATH, 'utf8'))
+  console.log(`Loaded ${listed.size} SGCN names from ${CSV_PATH}`)
+
+  const db = new Database(DB_PATH)
+  ensureColumn(db)
+
+  const targets = db
+    .prepare(
+      `SELECT id, genus, species FROM specimens
+       WHERE genus IS NOT NULL AND TRIM(genus) <> ''
+         AND species IS NOT NULL AND TRIM(species) <> ''`,
+    )
+    .all() as Array<SpecimenRow>
+
+  const update = db.prepare('UPDATE specimens SET texas_sgcn = ? WHERE id = ?')
+
+  let matched = 0
+  const applyAll = db.transaction((rows: Array<SpecimenRow>) => {
+    for (const row of rows) {
+      const flag = isSgcnListed(row.genus, row.species, listed) ? 'SGCN' : null
+      if (flag) matched++
+      update.run(flag, row.id)
+    }
+  })
+  applyAll(targets)
+
+  db.pragma('wal_checkpoint(TRUNCATE)')
+  db.close()
+
+  console.log('\n--- Coverage ---')
+  console.log(`  Specimens scanned: ${targets.length}`)
+  console.log(`  SGCN matched:      ${matched}`)
+  console.log(`\nDone! Updated ${DB_PATH}`)
+  console.log('To push to Turso: turso db import imrs-species.db')
+}
+
+main()

--- a/scripts/seed-sgcn.ts
+++ b/scripts/seed-sgcn.ts
@@ -4,8 +4,9 @@
  *
  * Unlike NatureServe and IUCN (seeded from live APIs by seed-conservation.ts),
  * the Texas Parks & Wildlife Department (TPWD) State Wildlife Action Plan SGCN
- * list has no public API, so it ships as a static CSV checked into the repo at
- * src/data/tpwd-sgcn-list.csv. This script adds a nullable `texas_sgcn` column
+ * list has no public API. The operator must supply it as a local CSV at
+ * src/data/tpwd-sgcn-list.csv (git-ignored, not committed — a fresh clone won't
+ * have it). This script adds a nullable `texas_sgcn` column
  * to the existing `specimens` table and sets it to 'SGCN' for every specimen
  * whose binomial (genus + species) exactly matches a name on the list.
  *

--- a/src/components/ConservationBadge.test.tsx
+++ b/src/components/ConservationBadge.test.tsx
@@ -42,4 +42,11 @@ describe('ConservationBadge', () => {
     render(<ConservationBadge rank={rank('natureserve-global', 'G5')} />)
     expect(screen.getByLabelText(/Secure/).className).toMatch(/bg-green-700/)
   })
+
+  it('uses the flag (teal) class for the binary SGCN designation', () => {
+    render(<ConservationBadge rank={rank('texas-sgcn', 'SGCN')} />)
+    expect(screen.getByLabelText(/Texas SGCN: Listed/).className).toMatch(
+      /bg-teal-700/,
+    )
+  })
 })

--- a/src/components/ConservationBadge.tsx
+++ b/src/components/ConservationBadge.tsx
@@ -10,6 +10,7 @@ const TIER_CLASSES: Record<ConservationTier, string> = {
   high: 'border-transparent bg-orange-600 text-white',
   moderate: 'border-transparent bg-amber-500 text-amber-950',
   secure: 'border-transparent bg-green-700 text-white',
+  flag: 'border-transparent bg-teal-700 text-white',
   unknown: 'border-transparent bg-gray-400 text-gray-900',
 }
 

--- a/src/components/Observations.tsx
+++ b/src/components/Observations.tsx
@@ -46,11 +46,12 @@ const GROUP_OPTIONS: Array<{ value: TaxonGroup; label: string }> = [
 
 type MediaType = 'all' | 'photos' | 'audio'
 
-const MEDIA_OPTIONS: Array<{ value: MediaType; label: string }> = [
-  { value: 'all', label: 'All Media' },
-  { value: 'photos', label: 'Photos' },
-  { value: 'audio', label: 'Audio' },
-]
+// Media filter temporarily hidden from the UI (see commented-out Select below).
+// const MEDIA_OPTIONS: Array<{ value: MediaType; label: string }> = [
+//   { value: 'all', label: 'All Media' },
+//   { value: 'photos', label: 'Photos' },
+//   { value: 'audio', label: 'Audio' },
+// ]
 
 // Stable, filter-independent descending year range for the Year dropdown.
 const CURRENT_YEAR = new Date().getFullYear()
@@ -71,7 +72,9 @@ interface ObservationsProps {
 
 const Observations = ({ initialPage }: ObservationsProps) => {
   const [selectedGroup, setSelectedGroup] = useState<TaxonGroup>('all')
-  const [mediaType, setMediaType] = useState<MediaType>('all')
+  // Media filter hidden from UI for now; stays wired into the query (always
+  // 'all') so re-enabling only means restoring the setter + the Select below.
+  const [mediaType] = useState<MediaType>('all')
   const [selectedYear, setSelectedYear] = useState<string>('all')
   const isUnfiltered =
     selectedGroup === 'all' && mediaType === 'all' && selectedYear === 'all'
@@ -179,14 +182,14 @@ const Observations = ({ initialPage }: ObservationsProps) => {
             </span>
           )}
 
-          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+          <div className="flex flex-row gap-2 sm:flex-wrap sm:items-center">
             <Select
               value={selectedGroup}
               onValueChange={(value) => setSelectedGroup(value as TaxonGroup)}
             >
               <SelectTrigger
                 aria-label="Filter by group"
-                className="w-48 cursor-pointer"
+                className="flex-1 cursor-pointer sm:w-48 sm:flex-none"
               >
                 <SelectValue placeholder="Filter by group" />
               </SelectTrigger>
@@ -203,13 +206,14 @@ const Observations = ({ initialPage }: ObservationsProps) => {
               </SelectContent>
             </Select>
 
+            {/* Media filter temporarily hidden from the UI (kept for re-enabling):
             <Select
               value={mediaType}
               onValueChange={(value) => setMediaType(value as MediaType)}
             >
               <SelectTrigger
                 aria-label="Filter by media type"
-                className="w-48 cursor-pointer"
+                className="flex-1 cursor-pointer sm:w-48 sm:flex-none"
               >
                 <SelectValue placeholder="Filter by media type" />
               </SelectTrigger>
@@ -221,11 +225,12 @@ const Observations = ({ initialPage }: ObservationsProps) => {
                 ))}
               </SelectContent>
             </Select>
+            */}
 
             <Select value={selectedYear} onValueChange={setSelectedYear}>
               <SelectTrigger
                 aria-label="Filter by year"
-                className="w-48 cursor-pointer"
+                className="flex-1 cursor-pointer sm:w-48 sm:flex-none"
               >
                 <SelectValue placeholder="Filter by year" />
               </SelectTrigger>

--- a/src/components/Observations.tsx
+++ b/src/components/Observations.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AudioLines, Calendar, MapPin, User } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { useInfiniteQuery } from '@tanstack/react-query'
@@ -22,7 +22,13 @@ import { getCategoryIcon } from '@/lib/getCategoryIcon'
 import { getPhotoUrl } from '@/lib/getPhotoUrl'
 import { getSoundUrl } from '@/lib/getSoundUrl'
 import { ObservationCardSkeleton } from '@/components/ObservationCardSkeleton'
-import { GC_TIME, PER_PAGE, SKELETON_COUNT, STALE_TIME } from '@/data/constants'
+import {
+  FIRST_OBSERVATION_YEAR,
+  GC_TIME,
+  PER_PAGE,
+  SKELETON_COUNT,
+  STALE_TIME,
+} from '@/data/constants'
 import { fetchObservations } from '@/lib/inat'
 import { GROUP_TO_TAXON_ID } from '@/types/taxon'
 
@@ -38,6 +44,21 @@ const GROUP_OPTIONS: Array<{ value: TaxonGroup; label: string }> = [
   { value: 'arachnid', label: 'Arachnids' },
 ]
 
+type MediaType = 'all' | 'photos' | 'audio'
+
+const MEDIA_OPTIONS: Array<{ value: MediaType; label: string }> = [
+  { value: 'all', label: 'All Media' },
+  { value: 'photos', label: 'Photos' },
+  { value: 'audio', label: 'Audio' },
+]
+
+// Stable, filter-independent descending year range for the Year dropdown.
+const CURRENT_YEAR = new Date().getFullYear()
+const YEAR_OPTIONS = Array.from(
+  { length: CURRENT_YEAR - FIRST_OBSERVATION_YEAR + 1 },
+  (_, i) => String(CURRENT_YEAR - i),
+)
+
 interface ObservationsPage {
   page: number
   per_page: number
@@ -50,19 +71,33 @@ interface ObservationsProps {
 
 const Observations = ({ initialPage }: ObservationsProps) => {
   const [selectedGroup, setSelectedGroup] = useState<TaxonGroup>('all')
+  const [mediaType, setMediaType] = useState<MediaType>('all')
+  const [selectedYear, setSelectedYear] = useState<string>('all')
+  const isUnfiltered =
+    selectedGroup === 'all' && mediaType === 'all' && selectedYear === 'all'
   const { ref, inView } = useInView({
     rootMargin: '200px',
   })
 
   const { data, fetchNextPage, hasNextPage, isFetching, isFetchingNextPage } =
     useInfiniteQuery({
-      queryKey: ['observations'],
+      queryKey: ['observations', selectedGroup, mediaType, selectedYear],
 
       initialPageParam: 1,
 
       queryFn: async ({ pageParam, signal }) => {
         const response = await fetchObservations(
-          { page: pageParam, per_page: PER_PAGE },
+          {
+            page: pageParam,
+            per_page: PER_PAGE,
+            taxon_id:
+              selectedGroup === 'all'
+                ? undefined
+                : GROUP_TO_TAXON_ID[selectedGroup],
+            photos: mediaType === 'photos' ? true : undefined,
+            sounds: mediaType === 'audio' ? true : undefined,
+            year: selectedYear === 'all' ? undefined : selectedYear,
+          },
           signal,
         )
 
@@ -75,11 +110,12 @@ const Observations = ({ initialPage }: ObservationsProps) => {
         }
       },
 
-      // Seed page 1 from SSR loader
-      initialData: {
-        pages: [initialPage],
-        pageParams: [1],
-      },
+      // Seed page 1 from SSR loader — only for the unfiltered view, so filtered
+      // queries fetch fresh from the API rather than reusing the seeded page.
+      // Function form keeps `data` typed as possibly undefined (it is, while a
+      // filtered query loads its first page).
+      initialData: () =>
+        isUnfiltered ? { pages: [initialPage], pageParams: [1] } : undefined,
 
       getNextPageParam: (lastPage) => {
         const loaded = lastPage.page * lastPage.per_page
@@ -93,8 +129,9 @@ const Observations = ({ initialPage }: ObservationsProps) => {
       gcTime: GC_TIME,
     })
 
-  // flatten pages
-  const observations = data.pages.flatMap((page) => page.results)
+  // flatten pages (data is undefined while a freshly-filtered query loads)
+  const observations = data?.pages.flatMap((page) => page.results) ?? []
+  const totalResults = data?.pages[0]?.total_results ?? 0
 
   // Infinite scroll trigger
   useEffect(() => {
@@ -103,20 +140,8 @@ const Observations = ({ initialPage }: ObservationsProps) => {
     }
   }, [inView, hasNextPage, isFetching, fetchNextPage])
 
-  const filteredObservations = useMemo(() => {
-    if (selectedGroup === 'all') return observations
-
-    const targetTaxonId = GROUP_TO_TAXON_ID[selectedGroup]
-    if (!targetTaxonId) return observations
-
-    return observations.filter((obs) => {
-      // Check if observation's taxon hierarchy includes the target group
-      const taxonIds = obs.taxon?.ancestor_ids || []
-      return taxonIds.includes(targetTaxonId)
-    })
-  }, [observations, selectedGroup])
-
-  if (!observations.length) {
+  // Genuinely empty feed (no filters applied) → friendly empty state.
+  if (isUnfiltered && !isFetching && observations.length === 0) {
     return <EmptyState />
   }
 
@@ -143,169 +168,225 @@ const Observations = ({ initialPage }: ObservationsProps) => {
           </p>
         </section>
 
-        <div className="sticky top-16 z-40 bg-background py-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          {selectedGroup !== 'all' ? (
+        <div className="sticky top-16 z-40 bg-background py-4 flex flex-col gap-3">
+          {!isUnfiltered && (
             <span
               className="text-sm text-muted-foreground"
               role="status"
               aria-live="polite"
             >
-              Showing {filteredObservations.length} of {observations.length}{' '}
-              observations
+              Showing {totalResults} matching observations
             </span>
-          ) : (
-            <span />
           )}
 
-          <Select
-            value={selectedGroup}
-            onValueChange={(value) => setSelectedGroup(value as TaxonGroup)}
-          >
-            <SelectTrigger
-              aria-label="Filter by group"
-              className="w-48 cursor-pointer"
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+            <Select
+              value={selectedGroup}
+              onValueChange={(value) => setSelectedGroup(value as TaxonGroup)}
             >
-              <SelectValue placeholder="Filter by group" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Groups</SelectItem>
-              {GROUP_OPTIONS.map(({ value, label }) => (
-                <SelectItem key={value} value={value}>
-                  <span className="flex items-center gap-2">
-                    {getCategoryIcon(value)}
+              <SelectTrigger
+                aria-label="Filter by group"
+                className="w-48 cursor-pointer"
+              >
+                <SelectValue placeholder="Filter by group" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Groups</SelectItem>
+                {GROUP_OPTIONS.map(({ value, label }) => (
+                  <SelectItem key={value} value={value}>
+                    <span className="flex items-center gap-2">
+                      {getCategoryIcon(value)}
+                      {label}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={mediaType}
+              onValueChange={(value) => setMediaType(value as MediaType)}
+            >
+              <SelectTrigger
+                aria-label="Filter by media type"
+                className="w-48 cursor-pointer"
+              >
+                <SelectValue placeholder="Filter by media type" />
+              </SelectTrigger>
+              <SelectContent>
+                {MEDIA_OPTIONS.map(({ value, label }) => (
+                  <SelectItem key={value} value={value}>
                     {label}
-                  </span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={selectedYear} onValueChange={setSelectedYear}>
+              <SelectTrigger
+                aria-label="Filter by year"
+                className="w-48 cursor-pointer"
+              >
+                <SelectValue placeholder="Filter by year" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Years</SelectItem>
+                {YEAR_OPTIONS.map((year) => (
+                  <SelectItem key={year} value={year}>
+                    {year}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
         <section>
-          <ul className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-            {filteredObservations.map((observation) => {
-              const photoUrl = getPhotoUrl(observation.photos)
-              const sound = getSoundUrl(observation.sounds)
-              const label =
-                observation.species_guess ||
-                observation.taxon?.preferred_common_name ||
-                `observation #${observation.id}`
+          {observations.length === 0 ? (
+            isFetching ? (
+              <ul className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+                  <li key={`skeleton-${i}`}>
+                    <ObservationCardSkeleton />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p
+                className="py-12 text-center text-muted-foreground"
+                role="status"
+              >
+                No observations match these filters.
+              </p>
+            )
+          ) : (
+            <ul className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {observations.map((observation) => {
+                const photoUrl = getPhotoUrl(observation.photos)
+                const sound = getSoundUrl(observation.sounds)
+                const label =
+                  observation.species_guess ||
+                  observation.taxon?.preferred_common_name ||
+                  `observation #${observation.id}`
 
-              return (
-                <li key={observation.id}>
-                  <Card className="h-full flex flex-col gradient-card shadow-card hover:shadow-hover transition-all duration-300 overflow-hidden">
-                    <Link
-                      to={observation.uri || '#'}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex flex-1 flex-col"
-                    >
-                      <span className="sr-only">
-                        {observation.species_guess ||
-                          observation.taxon?.preferred_common_name ||
-                          'Observation'}{' '}
-                        (opens in new tab)
-                      </span>
-                      {photoUrl ? (
-                        <div className="aspect-square overflow-hidden">
-                          <img
-                            src={photoUrl}
-                            alt={
-                              observation.species_guess ||
-                              observation.taxon?.preferred_common_name ||
-                              observation.taxon?.name ||
-                              `Observation #${observation.id}`
-                            }
-                            loading="lazy"
-                            decoding="async"
-                            width={500}
-                            height={500}
-                            className="w-full h-full object-cover hover:scale-105 transition-transform duration-300"
-                            onError={(e) => {
-                              ;(e.target as HTMLImageElement).style.display =
-                                'none'
-                            }}
-                          />
-                        </div>
-                      ) : (
-                        sound && (
-                          <div className="aspect-square flex items-center justify-center bg-muted">
-                            <AudioLines
-                              className="size-16 text-muted-foreground"
-                              aria-hidden="true"
-                            />
-                          </div>
-                        )
-                      )}
-
-                      <CardHeader className="pb-3 space-y-1">
-                        <h2 className="font-semibold text-foreground line-clamp-2">
+                return (
+                  <li key={observation.id}>
+                    <Card className="h-full flex flex-col gradient-card shadow-card hover:shadow-hover transition-all duration-300 overflow-hidden">
+                      <Link
+                        to={observation.uri || '#'}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex flex-1 flex-col"
+                      >
+                        <span className="sr-only">
                           {observation.species_guess ||
                             observation.taxon?.preferred_common_name ||
-                            'Unknown Species'}
-                        </h2>
-
-                        {observation.taxon?.name && (
-                          <p className="italic text-sm text-muted-foreground line-clamp-1">
-                            {observation.taxon.name}
-                          </p>
+                            'Observation'}{' '}
+                          (opens in new tab)
+                        </span>
+                        {photoUrl ? (
+                          <div className="aspect-square overflow-hidden">
+                            <img
+                              src={photoUrl}
+                              alt={
+                                observation.species_guess ||
+                                observation.taxon?.preferred_common_name ||
+                                observation.taxon?.name ||
+                                `Observation #${observation.id}`
+                              }
+                              loading="lazy"
+                              decoding="async"
+                              width={500}
+                              height={500}
+                              className="w-full h-full object-cover hover:scale-105 transition-transform duration-300"
+                              onError={(e) => {
+                                ;(e.target as HTMLImageElement).style.display =
+                                  'none'
+                              }}
+                            />
+                          </div>
+                        ) : (
+                          sound && (
+                            <div className="aspect-square flex items-center justify-center bg-muted">
+                              <AudioLines
+                                className="size-16 text-muted-foreground"
+                                aria-hidden="true"
+                              />
+                            </div>
+                          )
                         )}
-                      </CardHeader>
 
-                      <CardContent className="space-y-3 mt-auto">
-                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                          <User className="size-4" />
-                          <span>{observation.user?.login || 'Anonymous'}</span>
-                        </div>
+                        <CardHeader className="pb-3 space-y-1">
+                          <h2 className="font-semibold text-foreground line-clamp-2">
+                            {observation.species_guess ||
+                              observation.taxon?.preferred_common_name ||
+                              'Unknown Species'}
+                          </h2>
 
-                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                          <Calendar className="size-4" />
-                          <span>
-                            {formatDate(observation.observed_on_string)}
-                          </span>
-                        </div>
+                          {observation.taxon?.name && (
+                            <p className="italic text-sm text-muted-foreground line-clamp-1">
+                              {observation.taxon.name}
+                            </p>
+                          )}
+                        </CardHeader>
 
-                        {observation.place_guess && (
+                        <CardContent className="space-y-3 mt-auto">
                           <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                            <MapPin className="size-4" />
-                            <span className="line-clamp-1">
-                              {observation.place_guess}
+                            <User className="size-4" />
+                            <span>
+                              {observation.user?.login || 'Anonymous'}
                             </span>
                           </div>
-                        )}
 
-                        <Badge variant="secondary" className="w-fit">
-                          ID #{observation.id}
-                        </Badge>
-                      </CardContent>
-                    </Link>
+                          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <Calendar className="size-4" />
+                            <span>
+                              {formatDate(observation.observed_on_string)}
+                            </span>
+                          </div>
 
-                    {sound && (
-                      <div className="px-6 pb-4">
-                        {/* iNaturalist sound recordings ship no caption track;
+                          {observation.place_guess && (
+                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                              <MapPin className="size-4" />
+                              <span className="line-clamp-1">
+                                {observation.place_guess}
+                              </span>
+                            </div>
+                          )}
+
+                          <Badge variant="secondary" className="w-fit">
+                            ID #{observation.id}
+                          </Badge>
+                        </CardContent>
+                      </Link>
+
+                      {sound && (
+                        <div className="px-6 pb-4">
+                          {/* iNaturalist sound recordings ship no caption track;
                             the aria-label below provides the accessible name. */}
-                        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-                        <audio
-                          controls
-                          preload="none"
-                          className="w-full"
-                          aria-label={`Audio recording for ${label}`}
-                        >
-                          <source src={sound.url} type={sound.type} />
-                        </audio>
-                      </div>
-                    )}
-                  </Card>
-                </li>
-              )
-            })}
+                          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+                          <audio
+                            controls
+                            preload="none"
+                            className="w-full"
+                            aria-label={`Audio recording for ${label}`}
+                          >
+                            <source src={sound.url} type={sound.type} />
+                          </audio>
+                        </div>
+                      )}
+                    </Card>
+                  </li>
+                )
+              })}
 
-            {isFetchingNextPage &&
-              Array.from({ length: SKELETON_COUNT }).map((_, i) => (
-                <li key={`skeleton-${i}`}>
-                  <ObservationCardSkeleton />
-                </li>
-              ))}
-          </ul>
+              {isFetchingNextPage &&
+                Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+                  <li key={`skeleton-${i}`}>
+                    <ObservationCardSkeleton />
+                  </li>
+                ))}
+            </ul>
+          )}
 
           {isFetchingNextPage && (
             <span className="sr-only" role="status">

--- a/src/components/SpeciesDetails.tsx
+++ b/src/components/SpeciesDetails.tsx
@@ -378,8 +378,15 @@ export function SpeciesDetails() {
                 <CardHeader>
                   <CardTitle as="h2">Species Status</CardTitle>
                   <CardDescription>
-                    Conservation assessments. Source: NatureServe Explorer, the
-                    IUCN Red List, and Texas Parks &amp; Wildlife (SGCN).
+                    Conservation assessments from the following sources:
+                    <ul className="mt-2 list-disc pl-5 space-y-0.5">
+                      <li>NatureServe Explorer</li>
+                      <li>IUCN Red List</li>
+                      <li>
+                        Texas Parks &amp; Wildlife — Species of Greatest
+                        Conservation Need (SGCN)
+                      </li>
+                    </ul>
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="p-0">

--- a/src/components/SpeciesDetails.tsx
+++ b/src/components/SpeciesDetails.tsx
@@ -378,8 +378,8 @@ export function SpeciesDetails() {
                 <CardHeader>
                   <CardTitle as="h2">Species Status</CardTitle>
                   <CardDescription>
-                    Conservation assessments. Source: NatureServe Explorer and
-                    the IUCN Red List.
+                    Conservation assessments. Source: NatureServe Explorer, the
+                    IUCN Red List, and Texas Parks &amp; Wildlife (SGCN).
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="p-0">

--- a/src/components/SpeciesGridView.tsx
+++ b/src/components/SpeciesGridView.tsx
@@ -34,9 +34,12 @@ const SpeciesCard = memo(function SpeciesCard({ item }: { item: Species }) {
     setActive(false)
   }
 
-  useEffect(() => () => {
-    if (timerRef.current) clearTimeout(timerRef.current)
-  }, [])
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    },
+    [],
+  )
 
   const { url } = useSpeciesHoverImage(item, active)
   const onPhoto = active && !!url

--- a/src/components/SpeciesGridView.tsx
+++ b/src/components/SpeciesGridView.tsx
@@ -1,5 +1,6 @@
-import { memo, useRef } from 'react'
+import { memo, useEffect, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
+import { m, useReducedMotion } from 'framer-motion'
 import { useMediaQuery } from '@uidotdev/usehooks'
 import { useWindowVirtualizer } from '@tanstack/react-virtual'
 import type { Species } from '@/types/species'
@@ -9,30 +10,98 @@ import { ConservationBadge } from '@/components/ConservationBadge'
 import { getCategoryIcon } from '@/lib/getCategoryIcon'
 import { getMostAtRiskRank } from '@/lib/conservation'
 import { speciesPath } from '@/lib/speciesSlug'
+import { useSpeciesHoverImage } from '@/lib/useSpeciesHoverImage'
+
+const HOVER_INTENT_MS = 150
 
 const ESTIMATED_ROW_HEIGHT = 160
 
 const SpeciesCard = memo(function SpeciesCard({ item }: { item: Species }) {
   const status = getMostAtRiskRank(item)
+  const shouldReduceMotion = useReducedMotion()
+
+  // Hover/focus intent: only flip `active` after a short delay so sweeping the
+  // mouse across the grid doesn't fire a burst of iNaturalist requests.
+  const [active, setActive] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const activate = () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setActive(true), HOVER_INTENT_MS)
+  }
+  const deactivate = () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setActive(false)
+  }
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+  }, [])
+
+  const { url } = useSpeciesHoverImage(item, active)
+  const onPhoto = active && !!url
+
+  const scientificName =
+    `${item.genus ?? ''} ${item.species ?? ''}`.trim() || 'Unidentified species'
+
   return (
     <Link
       to="/species/$speciesId"
       params={{ speciesId: speciesPath(item) }}
       className="h-full block group"
+      onMouseEnter={activate}
+      onMouseLeave={deactivate}
+      onFocus={activate}
+      onBlur={deactivate}
     >
-      <Card className="gradient-card shadow-card hover:shadow-hover transition-all duration-300 cursor-pointer h-full hover:bg-muted/50">
-        <CardContent className="p-4 sm:p-6 h-full">
+      <Card className="gradient-card shadow-card hover:shadow-hover transition-all duration-300 cursor-pointer h-full hover:bg-muted/50 relative overflow-hidden">
+        {url && (
+          <m.div
+            className="absolute inset-0 pointer-events-none"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: onPhoto ? 1 : 0 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.3 }}
+          >
+            <img
+              src={url}
+              alt={
+                item.species_common_name
+                  ? `${scientificName} (${item.species_common_name})`
+                  : scientificName
+              }
+              loading="lazy"
+              decoding="async"
+              className="w-full h-full object-cover"
+              onError={(e) => {
+                ;(e.currentTarget.parentElement as HTMLElement).style.display =
+                  'none'
+              }}
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/75 via-black/35 to-black/10" />
+          </m.div>
+        )}
+        <CardContent className="p-4 sm:p-6 h-full relative z-10">
           <div className="flex flex-col h-full justify-between">
             <div className="flex items-start gap-4">
               <div className="flex-1 min-w-0">
                 <div className="flex flex-col gap-1 mb-2">
                   <div className="flex items-center gap-2">
                     {item.category && (
-                      <span className="text-muted-foreground group-hover:text-primary transition-colors">
+                      <span
+                        className={
+                          onPhoto
+                            ? 'text-white'
+                            : 'text-muted-foreground group-hover:text-primary transition-colors'
+                        }
+                      >
                         {getCategoryIcon(item.category)}
                       </span>
                     )}
-                    <h2 className="scientific-name text-lg font-medium truncate group-hover:underline">
+                    <h2
+                      className={`scientific-name text-lg font-medium truncate group-hover:underline ${
+                        onPhoto ? 'text-white' : ''
+                      }`}
+                    >
                       {item.genus || item.species ? (
                         `${item.genus ?? ''} ${item.species ?? ''}`.trim()
                       ) : (
@@ -42,13 +111,21 @@ const SpeciesCard = memo(function SpeciesCard({ item }: { item: Species }) {
                   </div>
 
                   {item.species_common_name && (
-                    <span className="text-foreground font-semibold truncate">
+                    <span
+                      className={`font-semibold truncate ${
+                        onPhoto ? 'text-white' : 'text-foreground'
+                      }`}
+                    >
                       {item.species_common_name}
                     </span>
                   )}
                 </div>
 
-                <p className="text-xs text-muted-foreground font-mono mb-2 truncate">
+                <p
+                  className={`text-xs font-mono mb-2 truncate ${
+                    onPhoto ? 'text-white/90' : 'text-muted-foreground'
+                  }`}
+                >
                   {[item.phylum, item.class_name, item.order_name, item.family]
                     .flatMap((crumb) => {
                       const trimmed = crumb?.trim()

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+function DialogOverlay({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & {
+  ref?: React.Ref<React.ElementRef<typeof DialogPrimitive.Overlay>>
+}) {
+  return (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      className={cn(
+        `fixed inset-0 z-40 bg-foreground/40 backdrop-blur-sm
+        data-[state=open]:animate-in data-[state=closed]:animate-out
+        data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+  ref?: React.Ref<React.ElementRef<typeof DialogPrimitive.Content>>
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          `fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2
+          flex flex-col
+          w-[calc(100%-2rem)] max-w-2xl max-h-[90vh]
+          bg-card text-card-foreground
+          border border-border shadow-card
+          data-[state=open]:animate-in data-[state=closed]:animate-out
+          data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0
+          data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95`,
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close
+          className="absolute right-4 top-4 cursor-pointer p-1 text-foreground/70 hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none"
+          aria-label="Close"
+        >
+          <X className="size-4" />
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'grid gap-1.5 px-6 py-4 border-b border-border',
+      className,
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = 'DialogHeader'
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse gap-2 px-6 py-4 border-t border-border sm:flex-row sm:justify-end',
+      className,
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = 'DialogFooter'
+
+function DialogTitle({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title> & {
+  ref?: React.Ref<React.ElementRef<typeof DialogPrimitive.Title>>
+}) {
+  return (
+    <DialogPrimitive.Title
+      ref={ref}
+      className={cn(
+        'text-lg font-semibold tracking-tight text-foreground',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ref,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description> & {
+  ref?: React.Ref<React.ElementRef<typeof DialogPrimitive.Description>>
+}) {
+  return (
+    <DialogPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Label({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'label'> & { ref?: React.Ref<HTMLLabelElement> }) {
+  return (
+    // Reusable primitive: consumers associate it via the htmlFor prop.
+    // eslint-disable-next-line jsx-a11y/label-has-associated-control
+    <label
+      ref={ref}
+      className={cn(
+        'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -143,7 +143,7 @@ function SelectItem({
     <SelectPrimitive.Item
       ref={ref}
       className={cn(
-        'relative flex w-full cursor-default select-none items-center py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        'relative flex w-full cursor-pointer select-none items-center py-1.5 pl-2 pr-8 text-sm outline-none hover:bg-accent data-[highlighted]:bg-accent focus:bg-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -91,7 +91,7 @@ function SelectContent({
       <SelectPrimitive.Content
         ref={ref}
         className={cn(
-          'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]',
+          'relative z-50 max-h-[var(--radix-select-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[var(--radix-select-content-transform-origin)]',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className,

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Textarea({
+  className,
+  ref,
+  ...props
+}: React.ComponentProps<'textarea'> & {
+  ref?: React.Ref<HTMLTextAreaElement>
+}) {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-20 w-full border border-input bg-transparent px-3 py-2 text-base shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/components/weather/WeatherDashboard.tsx
+++ b/src/components/weather/WeatherDashboard.tsx
@@ -3,7 +3,7 @@ import { Monitor } from 'lucide-react'
 import WeatherFilterBar from './WeatherFilterBar'
 import WeatherStatCards from './WeatherStatCards'
 import WeatherTimeSeries from './WeatherTimeSeries'
-import WeatherDataRequestDialog from './WeatherDataRequestDialog'
+// import WeatherDataRequestDialog from './WeatherDataRequestDialog'
 import type { WeatherFilters } from '@/types/weather'
 import { Route } from '@/routes/weather'
 import { useWeatherDaily, useWeatherSummary } from '@/hooks/useWeatherData'
@@ -27,7 +27,7 @@ export default function WeatherDashboard() {
             2020&ndash;2024
           </p>
         </div>
-        <WeatherDataRequestDialog />
+        {/* <WeatherDataRequestDialog /> */}
       </div>
 
       {isMobile && (

--- a/src/components/weather/WeatherDashboard.tsx
+++ b/src/components/weather/WeatherDashboard.tsx
@@ -3,6 +3,7 @@ import { Monitor } from 'lucide-react'
 import WeatherFilterBar from './WeatherFilterBar'
 import WeatherStatCards from './WeatherStatCards'
 import WeatherTimeSeries from './WeatherTimeSeries'
+import WeatherDataRequestDialog from './WeatherDataRequestDialog'
 import type { WeatherFilters } from '@/types/weather'
 import { Route } from '@/routes/weather'
 import { useWeatherDaily, useWeatherSummary } from '@/hooks/useWeatherData'
@@ -18,12 +19,15 @@ export default function WeatherDashboard() {
 
   return (
     <main className="container mx-auto px-4 py-8">
-      <div className="space-y-2 mb-8">
-        <h1 className="text-3xl font-semibold">Climate &amp; Weather</h1>
-        <p className="text-sm text-muted-foreground">
-          Hill Station &middot; Indio Mountains Research Station &middot;
-          2020&ndash;2024
-        </p>
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-semibold">Climate &amp; Weather</h1>
+          <p className="text-sm text-muted-foreground">
+            Hill Station &middot; Indio Mountains Research Station &middot;
+            2020&ndash;2024
+          </p>
+        </div>
+        <WeatherDataRequestDialog />
       </div>
 
       {isMobile && (

--- a/src/components/weather/WeatherDataRequestDialog.tsx
+++ b/src/components/weather/WeatherDataRequestDialog.tsx
@@ -1,6 +1,6 @@
 import { useId, useState } from 'react'
 import { z } from 'zod'
-import { Download } from 'lucide-react'
+import { Download, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -184,6 +184,7 @@ export default function WeatherDataRequestDialog() {
   const [values, setValues] = useState(initialValues)
   const [touched, setTouched] = useState<Record<string, boolean>>({})
   const [status, setStatus] = useState<SubmitStatus>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
 
   const parsed = requestSchema.safeParse(values)
   const isValid = parsed.success
@@ -244,6 +245,7 @@ export default function WeatherDataRequestDialog() {
     setValues(initialValues)
     setTouched({})
     setStatus('idle')
+    setErrorMessage('')
   }
 
   async function handleSubmit(event: React.FormEvent) {
@@ -252,6 +254,13 @@ export default function WeatherDataRequestDialog() {
 
     const formId = import.meta.env.VITE_FORMSPREE_FORM_ID
     if (!formId) {
+      console.error(
+        'WeatherDataRequestDialog: VITE_FORMSPREE_FORM_ID is not set. ' +
+          'Set it in .env.local and restart the dev server to enable submissions.',
+      )
+      setErrorMessage(
+        'This form is not set up correctly yet, so requests cannot be sent. Please contact the site administrator.',
+      )
       setStatus('error')
       return
     }
@@ -270,11 +279,17 @@ export default function WeatherDataRequestDialog() {
           submittedAt: new Date().toISOString(),
         }),
       })
-      if (!response.ok) throw new Error('Request failed')
+      if (!response.ok) {
+        throw new Error(`Formspree responded with status ${response.status}`)
+      }
       setStatus('success')
       setValues(initialValues)
       setTouched({})
-    } catch {
+    } catch (error) {
+      console.error('WeatherDataRequestDialog: failed to send request', error)
+      setErrorMessage(
+        'Something went wrong sending your request. Please check your connection and try again.',
+      )
       setStatus('error')
     }
   }
@@ -297,10 +312,12 @@ export default function WeatherDataRequestDialog() {
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Request raw weather data</DialogTitle>
-          <DialogDescription>
-            Tell us a bit about you and the data you need. We&rsquo;ll follow up
-            by email.
-          </DialogDescription>
+          {status !== 'success' && (
+            <DialogDescription>
+              Tell us a bit about you and the data you need. We&rsquo;ll follow
+              up by email.
+            </DialogDescription>
+          )}
         </DialogHeader>
 
         {status === 'success' ? (
@@ -655,8 +672,7 @@ export default function WeatherDataRequestDialog() {
 
               {status === 'error' && (
                 <p role="alert" className="text-sm text-destructive">
-                  Something went wrong sending your request. Please try again
-                  later.
+                  {errorMessage}
                 </p>
               )}
             </div>
@@ -667,7 +683,14 @@ export default function WeatherDataRequestDialog() {
                 disabled={status === 'submitting' || !isValid}
                 className="cursor-pointer"
               >
-                {status === 'submitting' ? 'Sending…' : 'Send request'}
+                {status === 'submitting' ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                    Sending…
+                  </>
+                ) : (
+                  'Send request'
+                )}
               </Button>
             </DialogFooter>
           </form>

--- a/src/components/weather/WeatherDataRequestDialog.tsx
+++ b/src/components/weather/WeatherDataRequestDialog.tsx
@@ -1,0 +1,743 @@
+import { useId, useState } from 'react'
+import { z } from 'zod'
+import { Download } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+const VARIABLES = [
+  'Temperature',
+  'Relative humidity',
+  'Dew point',
+  'Rainfall',
+  'Wind speed',
+  'Wind gust',
+  'Pressure',
+] as const
+
+const ROLES = [
+  { value: 'student', label: 'Student' },
+  { value: 'faculty', label: 'Faculty / Researcher' },
+  { value: 'other', label: 'Other' },
+] as const
+
+const PURPOSES = [
+  { value: 'research', label: 'Research' },
+  { value: 'education', label: 'Education / Teaching' },
+  { value: 'personal', label: 'Personal' },
+  { value: 'other', label: 'Other' },
+] as const
+
+const RESOLUTIONS = [
+  { value: '15min', label: '15-minute (raw)' },
+  { value: 'hourly', label: 'Hourly' },
+  { value: 'daily', label: 'Daily' },
+] as const
+
+const FORMATS = [
+  { value: 'csv', label: 'CSV' },
+  { value: 'excel', label: 'Excel' },
+] as const
+
+// Reject HTML angle brackets in free-text identity fields to avoid markup
+// being carried into the request email.
+const noAngleBrackets = z
+  .string()
+  .regex(/^[^<>]*$/u, 'Cannot contain the characters < or >')
+
+const requestSchema = z
+  .object({
+    fullName: z
+      .string()
+      .trim()
+      .min(1, 'Full name is required')
+      .max(100, 'Must be 100 characters or fewer')
+      .pipe(noAngleBrackets),
+    email: z
+      .string()
+      .trim()
+      .min(1, 'Email is required')
+      .max(254, 'Email is too long')
+      .email('Enter a valid email address'),
+    organization: z
+      .string()
+      .trim()
+      .max(200, 'Must be 200 characters or fewer')
+      .pipe(noAngleBrackets),
+    role: z.enum(['student', 'faculty', 'other'], {
+      message: 'Please select a role',
+    }),
+    pi: z
+      .string()
+      .trim()
+      .max(100, 'Must be 100 characters or fewer')
+      .pipe(noAngleBrackets),
+    roleOther: z
+      .string()
+      .trim()
+      .max(100, 'Must be 100 characters or fewer')
+      .pipe(noAngleBrackets),
+    purpose: z.enum(['research', 'education', 'personal', 'other'], {
+      message: 'Please select a purpose',
+    }),
+    description: z
+      .string()
+      .trim()
+      .min(1, 'Please describe how the data will be used')
+      .max(2000, 'Must be 2000 characters or fewer'),
+    published: z.enum(['yes', 'no'], {
+      message: 'Please indicate whether results will be published',
+    }),
+    variables: z.array(z.string()).min(1, 'Select at least one variable'),
+    startDate: z.string().min(1, 'Start date is required'),
+    endDate: z.string().min(1, 'End date is required'),
+    resolution: z.enum(['15min', 'hourly', 'daily'], {
+      message: 'Please select a temporal resolution',
+    }),
+    format: z.enum(['csv', 'excel'], {
+      message: 'Please select a file format',
+    }),
+    ackCite: z.literal(true, { message: 'Acknowledgment is required' }),
+    ackShare: z.literal(true, { message: 'Acknowledgment is required' }),
+    ackAsIs: z.literal(true, { message: 'Acknowledgment is required' }),
+    consent: z.literal(true, { message: 'Consent is required' }),
+  })
+  .refine((data) => data.startDate <= data.endDate, {
+    path: ['endDate'],
+    message: 'End date must be on or after the start date',
+  })
+
+const MAX_LENGTHS = {
+  fullName: 100,
+  email: 254,
+  organization: 200,
+  pi: 100,
+  roleOther: 100,
+  description: 2000,
+  startDate: 10,
+  endDate: 10,
+} as const
+
+type TextField = keyof typeof MAX_LENGTHS
+
+type FieldErrors = Partial<Record<string, string>>
+
+const initialValues = {
+  fullName: '',
+  email: '',
+  organization: '',
+  role: '',
+  pi: '',
+  roleOther: '',
+  purpose: '',
+  description: '',
+  published: '',
+  variables: [] as Array<string>,
+  startDate: '',
+  endDate: '',
+  resolution: '',
+  format: '',
+  ackCite: false,
+  ackShare: false,
+  ackAsIs: false,
+  consent: false,
+}
+
+type SubmitStatus = 'idle' | 'submitting' | 'success' | 'error'
+
+export default function WeatherDataRequestDialog() {
+  const ids = {
+    fullName: useId(),
+    email: useId(),
+    organization: useId(),
+    role: useId(),
+    pi: useId(),
+    roleOther: useId(),
+    purpose: useId(),
+    description: useId(),
+    published: useId(),
+    variables: useId(),
+    startDate: useId(),
+    endDate: useId(),
+    resolution: useId(),
+    format: useId(),
+  }
+
+  const [open, setOpen] = useState(false)
+  const [values, setValues] = useState(initialValues)
+  const [touched, setTouched] = useState<Record<string, boolean>>({})
+  const [status, setStatus] = useState<SubmitStatus>('idle')
+
+  const parsed = requestSchema.safeParse(values)
+  const isValid = parsed.success
+
+  const fieldErrors: FieldErrors = {}
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      const key = issue.path[0]
+      if (typeof key === 'string' && !fieldErrors[key]) {
+        fieldErrors[key] = issue.message
+      }
+    }
+  }
+
+  // Only surface an error once the user has interacted with the field.
+  function errorFor(field: string) {
+    return touched[field] ? fieldErrors[field] : undefined
+  }
+
+  function setField<TKey extends keyof typeof initialValues>(
+    key: TKey,
+    value: (typeof initialValues)[TKey],
+  ) {
+    setValues((prev) => ({ ...prev, [key]: value }))
+  }
+
+  function markTouched(field: string) {
+    setTouched((prev) => ({ ...prev, [field]: true }))
+  }
+
+  function toggleVariable(variable: string) {
+    setValues((prev) => ({
+      ...prev,
+      variables: prev.variables.includes(variable)
+        ? prev.variables.filter((v) => v !== variable)
+        : [...prev.variables, variable],
+    }))
+  }
+
+  // Shared props for free-text inputs: controlled value, touch tracking,
+  // a hard length cap, and accessible error wiring.
+  function textProps(field: TextField) {
+    const error = errorFor(field)
+    return {
+      id: ids[field],
+      value: values[field],
+      maxLength: MAX_LENGTHS[field],
+      'aria-invalid': error ? true : undefined,
+      'aria-describedby': error ? `${ids[field]}-error` : undefined,
+      onChange: (
+        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+      ) => setField(field, e.target.value),
+      onBlur: () => markTouched(field),
+    }
+  }
+
+  function resetForm() {
+    setValues(initialValues)
+    setTouched({})
+    setStatus('idle')
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    if (!parsed.success) return
+
+    const formId = import.meta.env.VITE_FORMSPREE_FORM_ID
+    if (!formId) {
+      setStatus('error')
+      return
+    }
+
+    setStatus('submitting')
+    try {
+      const response = await fetch(`https://formspree.io/f/${formId}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({
+          ...parsed.data,
+          station: 'Hill Station — Indio Mountains Research Station',
+          submittedAt: new Date().toISOString(),
+        }),
+      })
+      if (!response.ok) throw new Error('Request failed')
+      setStatus('success')
+      setValues(initialValues)
+      setTouched({})
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) resetForm()
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" className="cursor-pointer">
+          <Download className="size-4" aria-hidden="true" />
+          Request raw weather data
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Request raw weather data</DialogTitle>
+          <DialogDescription>
+            Tell us a bit about you and the data you need. We&rsquo;ll follow up
+            by email.
+          </DialogDescription>
+        </DialogHeader>
+
+        {status === 'success' ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="flex-1 overflow-y-auto px-6 py-8 text-center"
+          >
+            <p className="text-base font-medium text-foreground">
+              Thank you &mdash; your request has been sent.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              We&rsquo;ll be in touch at the email you provided.
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-6 cursor-pointer"
+              onClick={() => setStatus('idle')}
+            >
+              Submit another request
+            </Button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} noValidate className="contents">
+            <div className="flex-1 overflow-y-auto px-6 py-4 space-y-8">
+              {/* Requester */}
+              <fieldset className="space-y-4">
+                <legend className="text-sm font-semibold text-foreground mb-2">
+                  Requester
+                </legend>
+                <Field
+                  id={ids.fullName}
+                  label="Full name"
+                  required
+                  error={errorFor('fullName')}
+                >
+                  <Input {...textProps('fullName')} />
+                </Field>
+                <Field
+                  id={ids.email}
+                  label="Email"
+                  required
+                  error={errorFor('email')}
+                >
+                  <Input type="email" inputMode="email" {...textProps('email')} />
+                </Field>
+                <Field
+                  id={ids.organization}
+                  label="Organization / institution"
+                  error={errorFor('organization')}
+                >
+                  <Input {...textProps('organization')} />
+                </Field>
+                <Field
+                  id={ids.role}
+                  label="Role"
+                  required
+                  error={errorFor('role')}
+                >
+                  <Select
+                    value={values.role}
+                    onValueChange={(v) => {
+                      setField('role', v)
+                      markTouched('role')
+                    }}
+                  >
+                    <SelectTrigger
+                      id={ids.role}
+                      className="cursor-pointer"
+                      aria-invalid={errorFor('role') ? true : undefined}
+                    >
+                      <SelectValue placeholder="Select a role" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ROLES.map((r) => (
+                        <SelectItem key={r.value} value={r.value}>
+                          {r.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+                {values.role === 'student' && (
+                  <Field
+                    id={ids.pi}
+                    label="Major professor / PI"
+                    error={errorFor('pi')}
+                  >
+                    <Input {...textProps('pi')} />
+                  </Field>
+                )}
+                {values.role === 'other' && (
+                  <Field
+                    id={ids.roleOther}
+                    label="Please specify your role"
+                    error={errorFor('roleOther')}
+                  >
+                    <Input {...textProps('roleOther')} />
+                  </Field>
+                )}
+              </fieldset>
+
+              {/* Use */}
+              <fieldset className="space-y-4">
+                <legend className="text-sm font-semibold text-foreground mb-2">
+                  Use
+                </legend>
+                <Field
+                  id={ids.purpose}
+                  label="Purpose"
+                  required
+                  error={errorFor('purpose')}
+                >
+                  <Select
+                    value={values.purpose}
+                    onValueChange={(v) => {
+                      setField('purpose', v)
+                      markTouched('purpose')
+                    }}
+                  >
+                    <SelectTrigger
+                      id={ids.purpose}
+                      className="cursor-pointer"
+                      aria-invalid={errorFor('purpose') ? true : undefined}
+                    >
+                      <SelectValue placeholder="Select a purpose" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PURPOSES.map((p) => (
+                        <SelectItem key={p.value} value={p.value}>
+                          {p.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+                <Field
+                  id={ids.description}
+                  label="Brief description of how the data will be used"
+                  required
+                  error={errorFor('description')}
+                >
+                  <Textarea {...textProps('description')} />
+                </Field>
+                <fieldset>
+                  <legend className="text-sm font-medium mb-2">
+                    Will results be published?
+                    <span aria-hidden="true" className="text-destructive">
+                      {' '}
+                      *
+                    </span>
+                  </legend>
+                  <div className="flex gap-6">
+                    {(['yes', 'no'] as const).map((option) => (
+                      <label
+                        key={option}
+                        className="flex cursor-pointer items-center gap-2 text-sm"
+                      >
+                        <input
+                          type="radio"
+                          name="published"
+                          value={option}
+                          checked={values.published === option}
+                          onChange={() => {
+                            setField('published', option)
+                            markTouched('published')
+                          }}
+                          className="size-4 cursor-pointer accent-primary"
+                        />
+                        {option === 'yes' ? 'Yes' : 'No'}
+                      </label>
+                    ))}
+                  </div>
+                  {errorFor('published') && (
+                    <FieldError message={errorFor('published')!} />
+                  )}
+                </fieldset>
+              </fieldset>
+
+              {/* Data requested */}
+              <fieldset className="space-y-4">
+                <legend className="text-sm font-semibold text-foreground mb-2">
+                  Data requested
+                </legend>
+                <p className="text-sm text-muted-foreground">
+                  Station: Hill Station &mdash; Indio Mountains Research Station
+                </p>
+
+                <fieldset>
+                  <legend className="text-sm font-medium mb-2">
+                    Variables
+                    <span aria-hidden="true" className="text-destructive">
+                      {' '}
+                      *
+                    </span>
+                  </legend>
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    {VARIABLES.map((variable) => (
+                      <label
+                        key={variable}
+                        className="flex cursor-pointer items-center gap-2 text-sm"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={values.variables.includes(variable)}
+                          onChange={() => {
+                            toggleVariable(variable)
+                            markTouched('variables')
+                          }}
+                          className="size-4 cursor-pointer accent-primary"
+                        />
+                        {variable}
+                      </label>
+                    ))}
+                  </div>
+                  {errorFor('variables') && (
+                    <FieldError message={errorFor('variables')!} />
+                  )}
+                </fieldset>
+
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <Field
+                    id={ids.startDate}
+                    label="Start date"
+                    required
+                    error={errorFor('startDate')}
+                  >
+                    <Input type="date" {...textProps('startDate')} />
+                  </Field>
+                  <Field
+                    id={ids.endDate}
+                    label="End date"
+                    required
+                    error={errorFor('endDate')}
+                  >
+                    <Input type="date" {...textProps('endDate')} />
+                  </Field>
+                </div>
+
+                <Field
+                  id={ids.resolution}
+                  label="Temporal resolution"
+                  required
+                  error={errorFor('resolution')}
+                >
+                  <Select
+                    value={values.resolution}
+                    onValueChange={(v) => {
+                      setField('resolution', v)
+                      markTouched('resolution')
+                    }}
+                  >
+                    <SelectTrigger
+                      id={ids.resolution}
+                      className="cursor-pointer"
+                      aria-invalid={errorFor('resolution') ? true : undefined}
+                    >
+                      <SelectValue placeholder="Select a resolution" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {RESOLUTIONS.map((r) => (
+                        <SelectItem key={r.value} value={r.value}>
+                          {r.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+
+                <Field
+                  id={ids.format}
+                  label="File format"
+                  required
+                  error={errorFor('format')}
+                >
+                  <Select
+                    value={values.format}
+                    onValueChange={(v) => {
+                      setField('format', v)
+                      markTouched('format')
+                    }}
+                  >
+                    <SelectTrigger
+                      id={ids.format}
+                      className="cursor-pointer"
+                      aria-invalid={errorFor('format') ? true : undefined}
+                    >
+                      <SelectValue placeholder="Select a format" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {FORMATS.map((f) => (
+                        <SelectItem key={f.value} value={f.value}>
+                          {f.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+              </fieldset>
+
+              {/* Acknowledgment */}
+              <fieldset className="space-y-3">
+                <legend className="text-sm font-semibold text-foreground mb-2">
+                  Acknowledgment
+                </legend>
+                <CheckboxRow
+                  checked={values.ackCite}
+                  onChange={(c) => {
+                    setField('ackCite', c)
+                    markTouched('ackCite')
+                  }}
+                  error={errorFor('ackCite')}
+                >
+                  I agree to cite / acknowledge the Indio Mountains Research
+                  Station in any resulting publication.
+                </CheckboxRow>
+                <CheckboxRow
+                  checked={values.ackShare}
+                  onChange={(c) => {
+                    setField('ackShare', c)
+                    markTouched('ackShare')
+                  }}
+                  error={errorFor('ackShare')}
+                >
+                  I agree to share a copy of any resulting publications.
+                </CheckboxRow>
+                <CheckboxRow
+                  checked={values.ackAsIs}
+                  onChange={(c) => {
+                    setField('ackAsIs', c)
+                    markTouched('ackAsIs')
+                  }}
+                  error={errorFor('ackAsIs')}
+                >
+                  I understand the data is provided &ldquo;as is,&rdquo; with no
+                  warranty.
+                </CheckboxRow>
+                <CheckboxRow
+                  checked={values.consent}
+                  onChange={(c) => {
+                    setField('consent', c)
+                    markTouched('consent')
+                  }}
+                  error={errorFor('consent')}
+                >
+                  I consent to the above (a timestamp will be recorded with this
+                  request).
+                </CheckboxRow>
+              </fieldset>
+
+              {status === 'error' && (
+                <p role="alert" className="text-sm text-destructive">
+                  Something went wrong sending your request. Please try again
+                  later.
+                </p>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="submit"
+                disabled={status === 'submitting' || !isValid}
+                className="cursor-pointer"
+              >
+                {status === 'submitting' ? 'Sending…' : 'Send request'}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Field({
+  id,
+  label,
+  required,
+  error,
+  children,
+}: {
+  id: string
+  label: string
+  required?: boolean
+  error?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id}>
+        {label}
+        {required && (
+          <span aria-hidden="true" className="text-destructive">
+            {' '}
+            *
+          </span>
+        )}
+      </Label>
+      {children}
+      {error && <FieldError id={`${id}-error`} message={error} />}
+    </div>
+  )
+}
+
+function FieldError({ id, message }: { id?: string; message: string }) {
+  return (
+    <p id={id} className="text-sm text-destructive">
+      {message}
+    </p>
+  )
+}
+
+function CheckboxRow({
+  checked,
+  onChange,
+  error,
+  children,
+}: {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  error?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <label className="flex cursor-pointer items-start gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          className="mt-0.5 size-4 shrink-0 cursor-pointer accent-primary"
+        />
+        <span>{children}</span>
+      </label>
+      {error && <FieldError message={error} />}
+    </div>
+  )
+}

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -30,6 +30,9 @@ export const SKELETON_COUNT = 8
 export const PLACE_ID = '225419'
 export const ORDER = 'desc'
 export const ORDER_BY = 'observed_on'
+// Floor for the observations Year filter (iNaturalist's inception year), so no
+// real observation year is ever excluded from the dropdown.
+export const FIRST_OBSERVATION_YEAR = 2008
 export const STALE_TIME = 1000 * 60 * 60 * 24 * 30 // 30 days
 export const GC_TIME = 1000 * 60 * 60 * 24 * 60 // 60 days
 

--- a/src/lib/conservation.test.ts
+++ b/src/lib/conservation.test.ts
@@ -87,6 +87,22 @@ describe('normalizeRank', () => {
       'Presumed Extirpated',
     )
   })
+
+  it('maps Texas SGCN to a binary flag (severity 0, flag tier)', () => {
+    const rank = normalizeRank('texas-sgcn', 'SGCN')
+    expect(rank).toMatchObject({
+      source: 'texas-sgcn',
+      code: 'SGCN',
+      severity: 0,
+      tier: 'flag',
+      label: 'Listed',
+    })
+  })
+
+  it('returns null for an absent SGCN flag', () => {
+    expect(normalizeRank('texas-sgcn', null)).toBeNull()
+    expect(normalizeRank('texas-sgcn', '')).toBeNull()
+  })
 })
 
 describe('getConservationRanks', () => {
@@ -106,6 +122,13 @@ describe('getConservationRanks', () => {
     )
     expect(ranks).toHaveLength(1)
     expect(ranks[0].tier).toBe('unknown')
+  })
+
+  it('appends the SGCN flag in last position', () => {
+    const ranks = getConservationRanks(
+      speciesWith({ iucn_category: 'EN', texas_sgcn: 'SGCN' }),
+    )
+    expect(ranks.map((r) => r.source)).toEqual(['iucn', 'texas-sgcn'])
   })
 
   it('returns an empty array when there is no data', () => {
@@ -137,5 +160,9 @@ describe('getMostAtRiskRank', () => {
 
   it('returns null when there is no evaluated rank', () => {
     expect(getMostAtRiskRank(speciesWith({}))).toBeNull()
+  })
+
+  it('ignores the binary SGCN flag (kept off the grid badge)', () => {
+    expect(getMostAtRiskRank(speciesWith({ texas_sgcn: 'SGCN' }))).toBeNull()
   })
 })

--- a/src/lib/conservation.test.ts
+++ b/src/lib/conservation.test.ts
@@ -158,6 +158,13 @@ describe('getMostAtRiskRank', () => {
     ).toBeNull()
   })
 
+  it('omits secure (green) ranks from the grid badge', () => {
+    expect(getMostAtRiskRank(speciesWith({ iucn_category: 'LC' }))).toBeNull()
+    expect(
+      getMostAtRiskRank(speciesWith({ natureserve_grank: 'G5' })),
+    ).toBeNull()
+  })
+
   it('returns null when there is no evaluated rank', () => {
     expect(getMostAtRiskRank(speciesWith({}))).toBeNull()
   })

--- a/src/lib/conservation.ts
+++ b/src/lib/conservation.ts
@@ -11,12 +11,14 @@ export type ConservationSource =
   | 'iucn'
   | 'natureserve-global'
   | 'natureserve-tx'
+  | 'texas-sgcn'
 
 export type ConservationTier =
   | 'critical'
   | 'high'
   | 'moderate'
   | 'secure'
+  | 'flag'
   | 'unknown'
 
 export interface ConservationRank {
@@ -34,6 +36,7 @@ export const SOURCE_LABELS: Record<ConservationSource, string> = {
   iucn: 'IUCN Red List',
   'natureserve-global': 'NatureServe Global',
   'natureserve-tx': 'NatureServe (Texas)',
+  'texas-sgcn': 'Texas SGCN',
 }
 
 function severityToTier(severity: number): ConservationTier {
@@ -145,21 +148,36 @@ function normalizeIucn(raw: string): ConservationRank | null {
   }
 }
 
+// Texas SGCN is a binary designation (a species is on the State Wildlife Action
+// Plan list or it isn't), so it doesn't fit the 1–5 severity scale. It gets its
+// own `flag` tier with severity 0, which keeps it off the grid's most-at-risk
+// badge (filtered to severity ≥ 1) while still rendering on the detail page.
+function normalizeSgcn(): ConservationRank {
+  return {
+    source: 'texas-sgcn',
+    code: 'SGCN',
+    severity: 0,
+    tier: 'flag',
+    label: 'Listed',
+  }
+}
+
 /** Normalize a single raw code, or null if absent/unrecognized. */
 export function normalizeRank(
   source: ConservationSource,
   code: string | null | undefined,
 ): ConservationRank | null {
   if (code == null || code.trim() === '') return null
-  return source === 'iucn'
-    ? normalizeIucn(code)
-    : normalizeNatureServe(source, code)
+  if (source === 'iucn') return normalizeIucn(code)
+  if (source === 'texas-sgcn') return normalizeSgcn()
+  return normalizeNatureServe(source, code)
 }
 
 /**
  * All available ranks for a species, in fixed display order
- * (IUCN → NatureServe Global → NatureServe Texas). Includes "not evaluated"
- * ranks (informative on the detail page); absent fields are skipped.
+ * (IUCN → NatureServe Global → NatureServe Texas → Texas SGCN). Includes
+ * "not evaluated" ranks (informative on the detail page); absent fields are
+ * skipped.
  */
 export function getConservationRanks(
   species: Species,
@@ -168,6 +186,7 @@ export function getConservationRanks(
     normalizeRank('iucn', species.iucn_category),
     normalizeRank('natureserve-global', species.natureserve_grank),
     normalizeRank('natureserve-tx', species.natureserve_srank_tx),
+    normalizeRank('texas-sgcn', species.texas_sgcn),
   ].filter((rank): rank is ConservationRank => rank !== null)
 }
 

--- a/src/lib/conservation.ts
+++ b/src/lib/conservation.ts
@@ -191,14 +191,17 @@ export function getConservationRanks(
 }
 
 /**
- * The most at-risk evaluated rank, for the grid card badge. Lowest severity
- * (≥ 1) wins; ties break by source order (IUCN > Global > Texas). Returns null
- * when the species has no evaluated rank, so cards aren't littered with gray
- * "not evaluated" badges.
+ * The most at-risk evaluated rank, for the grid card badge. Only ranks of
+ * conservation concern qualify (severity 1–3: critical/high/moderate); secure
+ * "green" ranks (severity 4–5) and not-evaluated ranks (severity 0) are
+ * intentionally omitted so grid cards highlight only at-risk species. Lowest
+ * severity wins; ties break by source order (IUCN > Global > Texas). Returns
+ * null when the species has no at-risk rank. The full set of ranks, green
+ * included, is still shown on the detail page via getConservationRanks.
  */
 export function getMostAtRiskRank(species: Species): ConservationRank | null {
   const ranked = getConservationRanks(species).filter(
-    (rank) => rank.severity >= 1,
+    (rank) => rank.severity >= 1 && rank.severity <= 3,
   )
   if (ranked.length === 0) return null
   return ranked.reduce((worst, rank) =>

--- a/src/lib/inat.ts
+++ b/src/lib/inat.ts
@@ -66,8 +66,11 @@ interface FetchObservationsParams {
   page?: number
   per_page?: number
   taxon_name?: string
+  taxon_id?: number
   place_id?: string
   photos?: boolean
+  sounds?: boolean
+  year?: string
 }
 
 export async function fetchObservations(
@@ -88,8 +91,17 @@ export async function fetchObservations(
     url.searchParams.set('order', ORDER)
     url.searchParams.set('order_by', ORDER_BY)
   }
+  if (params.taxon_id != null) {
+    url.searchParams.set('taxon_id', String(params.taxon_id))
+  }
   if (params.photos) {
     url.searchParams.set('photos', 'true')
+  }
+  if (params.sounds) {
+    url.searchParams.set('sounds', 'true')
+  }
+  if (params.year) {
+    url.searchParams.set('year', params.year)
   }
   url.searchParams.set('per_page', String(params.per_page ?? PER_PAGE))
   if (params.page != null) {

--- a/src/lib/useSpeciesHoverImage.ts
+++ b/src/lib/useSpeciesHoverImage.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query'
+import type { Species } from '@/types/species'
+import { GC_TIME, STALE_TIME } from '@/data/constants'
+import { fetchObservations, taxonQueryName } from '@/lib/inat'
+import { getPhotoUrl } from '@/lib/getPhotoUrl'
+
+// Single owner of hover-image resolution for grid cards. Today it resolves the
+// top global iNaturalist photo for the species; a future iteration can check a
+// curated `Record<name, url>` here first and fall back to iNaturalist without
+// touching any card code.
+export function useSpeciesHoverImage(
+  species: Species,
+  enabled: boolean,
+): { url: string | null } {
+  const scientificName = taxonQueryName(species.genus, species.species)
+
+  const { data } = useQuery({
+    queryKey: ['hover-photo', scientificName],
+    queryFn: async ({ signal }) => {
+      const { results } = await fetchObservations(
+        { taxon_name: scientificName, photos: true, per_page: 1 },
+        signal,
+      )
+      return getPhotoUrl(results[0]?.photos)
+    },
+    enabled: enabled && scientificName.length > 0,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  })
+
+  return { url: data ?? null }
+}

--- a/src/lib/useSpeciesHoverImage.ts
+++ b/src/lib/useSpeciesHoverImage.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import type { Species } from '@/types/species'
 import { GC_TIME, STALE_TIME } from '@/data/constants'
@@ -14,7 +15,7 @@ export function useSpeciesHoverImage(
 ): { url: string | null } {
   const scientificName = taxonQueryName(species.genus, species.species)
 
-  const { data } = useQuery({
+  const { data, error } = useQuery({
     queryKey: ['hover-photo', scientificName],
     queryFn: async ({ signal }) => {
       const { results } = await fetchObservations(
@@ -27,6 +28,18 @@ export function useSpeciesHoverImage(
     staleTime: STALE_TIME,
     gcTime: GC_TIME,
   })
+
+  // The image is decorative, so a failure degrades silently in the UI — but log
+  // it so iNaturalist rate-limiting, outages, or schema drift stay diagnosable
+  // instead of looking identical to a species that simply has no photo.
+  useEffect(() => {
+    if (error) {
+      console.error(
+        `useSpeciesHoverImage: failed to resolve photo for "${scientificName}"`,
+        error,
+      )
+    }
+  }, [error, scientificName])
 
   return { url: data ?? null }
 }

--- a/src/server/speciesMapper.ts
+++ b/src/server/speciesMapper.ts
@@ -41,5 +41,6 @@ export function rowToSpecies(row: Record<string, unknown>): Species | null {
     natureserve_grank: row.natureserve_grank as string | undefined,
     natureserve_srank_tx: row.natureserve_srank_tx as string | undefined,
     natureserve_id: row.natureserve_id as string | undefined,
+    texas_sgcn: row.texas_sgcn as string | undefined,
   }
 }

--- a/src/types/species.ts
+++ b/src/types/species.ts
@@ -29,4 +29,5 @@ export interface Species {
   natureserve_grank?: string
   natureserve_srank_tx?: string
   natureserve_id?: string
+  texas_sgcn?: string
 }


### PR DESCRIPTION
## Summary

This PR builds on species grid card improvements and adds filtering to observations and weather data request capabilities.

## Changes

### Species Grid Cards
- **Hover image overlay**: Display hover images on grid cards with smooth transitions (748beab)
- **Texas SGCN integration**: Add Texas SGCN (Species of Greatest Conservation Need) conservation status badges (e1f7a14)
- **Fix badge display**: Exclude secure conservation ranks from grid card badges (8249ceb)
- **Format conservation sources**: Display conservation sources as a bulleted list for clarity (bf58653)

### Observations Filtering
- **Add year and media filters**: Support filtering observations by media type (photos/audio) and year (e3216eb)
- **API parameter support**: Extended `fetchObservations()` to support `taxon_id`, `sounds`, and `year` parameters
- **Temporarily hide media filter**: Media type filter is disabled in the UI but remains code-ready for re-enabling (4dd45e4)

### Weather Data Request Dialog
- **New Formspree integration**: Add `WeatherDataRequestDialog` component for requesting raw weather data (02b6f1c)
- **Error handling improvements**: Add better error messages, logging, and loading indicator (7815682)
- **ShadCN components**: Add dialog, label, and textarea UI components
- **Temporarily disabled**: Dialog is currently commented out pending final review (65652c1)

## Environment Setup
The weather data request form requires `VITE_FORMSPREE_FORM_ID` to be set in `.env.local`. See CLAUDE.md for details.

## Notes
- Some features (media filter, weather dialog) are temporarily hidden from the UI but remain fully implemented
- All filtering maintains proper query key management for TanStack Query cache invalidation